### PR TITLE
Add basic support for populating database from tsv files

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,3 +69,29 @@ docker-compose exec kp-translator python scripts/build_database.py
 ```
 
 This was generated using a modified TranslatorReasonersAPI.yaml that does not include the oneOf type definitions.
+
+### Knowledge Graph Exchange (KGX) File Ingest (In Development)
+
+To populate the database from KGX-formatted flat files (see 
+[Data preparation for use with KGX](https://github.com/NCATS-Tangerine/kgx/blob/master/data-preparation.md)), run the
+build_database.py script with the --db_config flag as follows
+
+```
+docker-compose exec kp-translator python scripts/build_database.py --db_config data/db_config_file.json
+```
+
+The contents of the configuration file (located in a 'data' subfolder in the above example) should look like this
+
+```
+{
+    "dataset1": 
+    {
+        "source_dir": "source-data-folder",
+        "nodes_file": "source-data-nodes.tsv",
+        "edges_file": "source-data-edges.tsv"
+    }
+}
+```
+
+In this example, the nodes and edges files, denoted by "nodes_file" and "edges_file" should be located in the
+subdirectory denoted by "source_dir".

--- a/kpTranslator/config.py
+++ b/kpTranslator/config.py
@@ -7,11 +7,6 @@ from kpTranslator import encoder
 basedir = os.path.abspath(os.path.dirname(__file__))
 db_file = os.path.join(basedir, 'translator_kg.db')
 
-# Delete database file if it exists currently
-if os.path.exists(db_file):
-    print("Deleting existing database file...")
-    os.remove(db_file)
-
 connex_app = connexion.App(__name__, specification_dir='./openapi/')
 
 # Get the underlying Flask app instance

--- a/kpTranslator/config.py
+++ b/kpTranslator/config.py
@@ -2,10 +2,15 @@ import os
 import connexion
 from flask_sqlalchemy import SQLAlchemy
 from flask_marshmallow import Marshmallow
+from kpTranslator import encoder
 
 basedir = os.path.abspath(os.path.dirname(__file__))
+db_file = os.path.join(basedir, 'translator_kg.db')
 
-from kpTranslator import encoder
+# Delete database file if it exists currently
+if os.path.exists(db_file):
+    print("Deleting existing database file...")
+    os.remove(db_file)
 
 connex_app = connexion.App(__name__, specification_dir='./openapi/')
 
@@ -15,7 +20,7 @@ app.json_encoder = encoder.JSONEncoder
 
 # Configure the SQLAlchemy part of the app instance
 app.config['SQLALCHEMY_ECHO'] = True
-app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:////' + os.path.join(basedir, 'people.db')
+app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:////' + db_file
 app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
 
 # Create the SQLAlchemy db instance

--- a/kpTranslator/controllers/query_controller.py
+++ b/kpTranslator/controllers/query_controller.py
@@ -1,9 +1,7 @@
 import connexion
 import six
 
-from kpTranslator.database.models import TranslatorKnowledgeGraphNode
 from kpTranslator.database.models import TranslatorKnowledgeGraphEdge
-from kpTranslator.serializers.translator_knowledge_graph_serializer import TranslatorKnowledgeGraphNodeSchema
 from kpTranslator.serializers.translator_knowledge_graph_serializer import TranslatorKnowledgeGraphEdgeSchema
 
 from kpTranslator.models.message import Message  # noqa: E501
@@ -22,16 +20,22 @@ def query(request_body):  # noqa: E501
     :rtype: Message
     """
     request = Query.from_dict(request_body)
+
+    if request is None:
+        return 'Query request is invalid!'
+
+    # Get query graph nodes
     query_graph = request.message.query_graph
-
     qnodes = query_graph.nodes
-    qedges = query_graph.edges
 
+    # Get the first valid node curie
     curie = None
     for k, v in qnodes.items():
         if v.curie is not None:
             curie = v.curie
+            break
 
+    # Return edges where the subject or object node matches the node curie
     if curie is not None:
         edges = TranslatorKnowledgeGraphEdge.query \
             .filter(

--- a/kpTranslator/controllers/query_controller.py
+++ b/kpTranslator/controllers/query_controller.py
@@ -19,14 +19,15 @@ def query(request_body):  # noqa: E501
 
     :rtype: Message
     """
+    # Parse request
     request = Query.from_dict(request_body)
 
-    if request is None:
-        return 'Query request is invalid!'
-
-    # Get query graph nodes
-    query_graph = request.message.query_graph
-    qnodes = query_graph.nodes
+    try:
+        # Get query graph nodes
+        query_graph = request.message.query_graph
+        qnodes = query_graph.nodes
+    except AttributeError as e:
+        return 'Query request is invalid!\n{}'.format(e)
 
     # Get the first valid node curie
     curie = None

--- a/kpTranslator/controllers/query_controller.py
+++ b/kpTranslator/controllers/query_controller.py
@@ -1,7 +1,13 @@
 import connexion
 import six
 
+from kpTranslator.database.models import TranslatorKnowledgeGraphNode
+from kpTranslator.database.models import TranslatorKnowledgeGraphEdge
+from kpTranslator.serializers.translator_knowledge_graph_serializer import TranslatorKnowledgeGraphNodeSchema
+from kpTranslator.serializers.translator_knowledge_graph_serializer import TranslatorKnowledgeGraphEdgeSchema
+
 from kpTranslator.models.message import Message  # noqa: E501
+from kpTranslator.models.query import Query
 from kpTranslator import util
 
 
@@ -15,4 +21,23 @@ def query(request_body):  # noqa: E501
 
     :rtype: Message
     """
-    return 'do some magic!'
+    request = Query.from_dict(request_body)
+    query_graph = request.message.query_graph
+
+    qnodes = query_graph.nodes
+    qedges = query_graph.edges
+
+    curie = None
+    for k, v in qnodes.items():
+        if v.curie is not None:
+            curie = v.curie
+
+    if curie is not None:
+        edges = TranslatorKnowledgeGraphEdge.query \
+            .filter(
+                (TranslatorKnowledgeGraphEdge.subject == curie) |
+                (TranslatorKnowledgeGraphEdge.object == curie)).all()
+        edges_schema = TranslatorKnowledgeGraphEdgeSchema(many=True)
+        return edges_schema.dump(edges)
+    else:
+        return 'Curie not found!'

--- a/kpTranslator/database/models.py
+++ b/kpTranslator/database/models.py
@@ -2,6 +2,22 @@ from datetime import datetime
 from datetime import datetime
 from kpTranslator.config import db, ma
 
+
 class TestModel(db.Model):
     id = db.Column(db.Integer, primary_key=True)
     name = db.Column(db.String(80))
+
+
+class TranslatorKnowledgeGraphNode(db.Model):
+    node_id = db.Column(db.Integer, primary_key=True)
+    id = db.Column(db.String(80), unique=False, nullable=False)
+    name = db.Column(db.String(80), unique=False, nullable=True)
+    category = db.Column(db.String(80), unique=False, nullable=False)
+
+
+class TranslatorKnowledgeGraphEdge(db.Model):
+    edge_id = db.Column(db.Integer, primary_key=True)
+    subject = db.Column(db.String(80), unique=False, nullable=False)
+    edge_label = db.Column(db.String(80), unique=False, nullable=False)
+    object = db.Column(db.String(80), unique=False, nullable=False)
+    relation = db.Column(db.String(80), unique=False, nullable=False)

--- a/kpTranslator/serializers/translator_knowledge_graph_serializer.py
+++ b/kpTranslator/serializers/translator_knowledge_graph_serializer.py
@@ -1,0 +1,15 @@
+from kpTranslator.database.models import TranslatorKnowledgeGraphNode
+from kpTranslator.database.models import TranslatorKnowledgeGraphEdge
+from kpTranslator.config import db, ma
+
+
+class TranslatorKnowledgeGraphNodeSchema(ma.SQLAlchemyAutoSchema):
+    class Meta:
+        model = TranslatorKnowledgeGraphNode
+        sqla_session = db.session
+
+
+class TranslatorKnowledgeGraphEdgeSchema(ma.SQLAlchemyAutoSchema):
+    class Meta:
+        model = TranslatorKnowledgeGraphEdge
+        sqla_session = db.session

--- a/kpTranslator/serializers/translator_knowledge_graph_serializer.py
+++ b/kpTranslator/serializers/translator_knowledge_graph_serializer.py
@@ -1,5 +1,4 @@
-from kpTranslator.database.models import TranslatorKnowledgeGraphNode
-from kpTranslator.database.models import TranslatorKnowledgeGraphEdge
+from kpTranslator.database.models import TranslatorKnowledgeGraphNode, TranslatorKnowledgeGraphEdge
 from kpTranslator.config import db, ma
 
 

--- a/scripts/build_database.py
+++ b/scripts/build_database.py
@@ -1,6 +1,66 @@
 import os
-from kpTranslator.config import db
-from kpTranslator.database.models import TestModel
+import csv
+import json
+import argparse
+from kpTranslator.config import db, db_file
+from kpTranslator.database.models import TestModel, TranslatorKnowledgeGraphNode, TranslatorKnowledgeGraphEdge
+
+parser = argparse.ArgumentParser()
+parser.add_argument('--db_config', help="Configuration file (.json) for populating database", default=None)
+args = parser.parse_args()
+
+# Delete database file if it exists currently
+if os.path.exists(db_file):
+    print("Deleting existing database file...")
+    os.remove(db_file)
+
+# Populate database from TSV files
+if args.db_config is not None:
+    db_config_file = os.path.join(os.path.abspath(os.path.dirname(__file__)), '..', args.db_config)
+    print('Database configuration file: {}'.format(db_config_file))
+
+    with open(db_config_file, 'r') as config_file:
+        config_data = json.load(config_file)
+
+    print(config_data)
+
+    for src, dat in config_data.items():
+        assert('source_dir' in list(dat.keys()))
+        assert('nodes_file' in list(dat.keys()))
+        assert('edges_file' in list(dat.keys()))
+
+        dat_root = os.path.dirname(db_config_file)
+        dat_path = os.path.join(dat_root, dat['source_dir'])
+        nodes_file = os.path.join(dat_root, dat['source_dir'], dat['nodes_file'])
+        edges_file = os.path.join(dat_root, dat['source_dir'], dat['edges_file'])
+        print(dat_path)
+        print(nodes_file)
+        print(edges_file)
+
+        node_count = 0
+        with open(nodes_file, 'r', newline='') as nodes_in:
+            nodes_reader = csv.reader(nodes_in, delimiter='\t')
+            headers = nodes_reader.__next__()
+            print(headers)
+            for node_record in nodes_reader:
+                node_data = {k: v for k, v in zip(headers, node_record)}
+                n = TranslatorKnowledgeGraphNode(
+                    id=node_data['id'], name=node_data['name'], category=node_data['category']
+                )
+                db.session.add(n)
+
+        edge_count = 0
+        with open(edges_file, 'r', newline='') as edges_in:
+            edges_reader = csv.reader(edges_in, delimiter='\t')
+            headers = edges_reader.__next__()
+            print(headers)
+            for edge_record in edges_reader:
+                edge_data = {k: v for k, v in zip(headers, edge_record)}
+                e = TranslatorKnowledgeGraphEdge(
+                    subject=edge_data['subject'], edge_label=edge_data['edge_label'], object=edge_data['object'],
+                    relation=edge_data['relation']
+                )
+                db.session.add(e)
 
 # Data to initialize database with
 TEST = [


### PR DESCRIPTION
Modified build_database.py script to accept db_config flag allowing specification
of a json config file pointing at the location of two tsv files, one with nodes
information and one with edges information. Running the script with this flag
causes the tsv files to be ingested and loaded into a sqlite database.

Added rudimentary code for processing a Translator Reasoner Standard API query and
returning a list of edges for which either the subject or object node matches the
first node curie encountered in the node list. See main README for the repo to
see syntax for running the build_database.py script. Add --db_config as flag and
provide path to a json config file structured as follows:

{
	"dataset1": {
		"source_dir": "source-data-folder",
		"nodes_file": "source-data-nodes.tsv",
		"edges_file": "source-data-edges.tsv"
	}
}

The source tsv files are expected to be in the folder (relative path) specified by
"source_dir".